### PR TITLE
PR 2: Performance — Fix N+1 queries, duplicate fetching, batch endpoints, server-side search

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -34,6 +34,9 @@ function App() {
     isConnected, 
     allDataLoaded, 
     hasData, 
+    users,
+    events,
+    eventsLoaded,
     refreshData, 
     retryConnection 
   } = useDataFetching();
@@ -149,7 +152,7 @@ function App() {
 
   return (
     <Box sx={{ flexGrow: 1 }}>
-      <Header onDataChanged={handleDataChanged} isConnected={isConnected} />
+      <Header onDataChanged={handleDataChanged} isConnected={isConnected} users={users} events={events} eventsLoaded={eventsLoaded} allDataLoaded={allDataLoaded} refreshData={refreshData} />
       <Container maxWidth="sm" sx={{ mt: 4 }}>
         <Box sx={{ 
           border: '1px solid #ddd', 

--- a/client/src/components/CreateEventForm.js
+++ b/client/src/components/CreateEventForm.js
@@ -94,13 +94,10 @@ function CreateEventForm({ open, onClose, onEventCreated }) {
 
     setUserSearchLoading(true);
     try {
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/users`);
+      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/users?search=${encodeURIComponent(searchTerm.trim())}`);
       if (response.ok) {
         const users = await response.json();
-        const filteredUsers = users.filter(user => 
-          (user.name && user.name.toLowerCase().includes(searchTerm.toLowerCase()))
-        );
-        setAvailableUsers(filteredUsers);
+        setAvailableUsers(users);
       }
     } catch (error) {
       console.error('Error searching users:', error);
@@ -117,13 +114,10 @@ function CreateEventForm({ open, onClose, onEventCreated }) {
 
     setOwnerSearchLoading(true);
     try {
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/users`);
+      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/users?search=${encodeURIComponent(searchTerm.trim())}`);
       if (response.ok) {
         const users = await response.json();
-        const filteredUsers = users.filter(user => 
-          (user.name && user.name.toLowerCase().includes(searchTerm.toLowerCase()))
-        );
-        setAvailableOwners(filteredUsers);
+        setAvailableOwners(users);
       }
     } catch (error) {
       console.error('Error searching owners:', error);
@@ -242,16 +236,17 @@ function CreateEventForm({ open, onClose, onEventCreated }) {
           item => item.itemName.trim() && item.amount && parseFloat(item.amount) > 0
         );
 
-        for (const item of validExpenseItems) {
-          await fetch(`${process.env.REACT_APP_API_URL}/api/expense-items`, {
+        if (validExpenseItems.length > 0) {
+          await fetch(`${process.env.REACT_APP_API_URL}/api/events/${createdEvent._id}/items/batch`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
             },
             body: JSON.stringify({
-              eventId: createdEvent._id,
-              itemName: item.itemName,
-              amount: parseFloat(item.amount)
+              items: validExpenseItems.map(item => ({
+                itemName: item.itemName,
+                amount: parseFloat(item.amount)
+              }))
             })
           });
         }

--- a/client/src/components/EventDetailView.js
+++ b/client/src/components/EventDetailView.js
@@ -125,26 +125,18 @@ function EventDetailView({ open, onClose, eventId, onEventUpdated, breadcrumbUse
   const searchUsers = async (searchTerm) => {
     setUserSearchLoading(true);
     try {
-      const response = await fetch(`${API_URL}/api/users`);
+      const url = searchTerm.trim()
+        ? `${API_URL}/api/users?search=${encodeURIComponent(searchTerm.trim())}`
+        : `${API_URL}/api/users`;
+      const response = await fetch(url);
       if (response.ok) {
         const users = await response.json();
         
-        // Get already added participant IDs
         const currentParticipantIds = participantDetails.map(p => p._id);
-        
-        // Filter users that aren't already participants
         const availableUsers = users.filter(user => 
           !currentParticipantIds.includes(user._id)
         );
         
-        // If search term is provided, filter by name
-        const searchFilteredUsers = searchTerm.trim() 
-          ? availableUsers.filter(user => 
-              user.name && user.name.toLowerCase().includes(searchTerm.toLowerCase())
-            )
-          : availableUsers;
-        
-        // Create the options array with "Add all" as first option if there are remaining users
         const options = [];
         if (availableUsers.length > 0) {
           options.push({
@@ -154,8 +146,7 @@ function EventDetailView({ open, onClose, eventId, onEventUpdated, breadcrumbUse
           });
         }
         
-        // Add the filtered users
-        options.push(...searchFilteredUsers);
+        options.push(...availableUsers);
         
         setAvailableUsers(options);
       }
@@ -441,16 +432,6 @@ function EventDetailView({ open, onClose, eventId, onEventUpdated, breadcrumbUse
       try {
         setLoading(true);
         
-        // Delete all expense items for this event
-        for (const item of expenseItems) {
-          if (!item.isNew) { // Only delete existing items
-            await fetch(`${API_URL}/api/expense-items/${item._id}`, {
-              method: 'DELETE'
-            });
-          }
-        }
-        
-        // Delete the event
         const response = await fetch(`${API_URL}/api/events/${eventId}`, {
           method: 'DELETE'
         });

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -10,11 +10,10 @@ import InsightsDisplay from './InsightsDisplay';
 import CreateUserForm from './CreateUserForm';
 import ExpandCollapseButton from './ExpandCollapseButton';
 import useFeatureToggles from '../hooks/useFeatureToggles';
-import useDataFetching from '../hooks/useDataFetching';
 
-function Header({ onDataChanged, isConnected = true }) {
+function Header({ onDataChanged, isConnected = true, users = [], events = [], eventsLoaded = false, allDataLoaded = false, refreshData }) {
   const { enableGossip, enableReminders, hasAnyFeature } = useFeatureToggles();
-  const { users, events, eventsLoaded, allDataLoaded, refreshData } = useDataFetching();
+
   
   const [isExpanded, setIsExpanded] = useState(true);
   const [showCreateUserForm, setShowCreateUserForm] = useState(false);

--- a/server/controllers/eventController.js
+++ b/server/controllers/eventController.js
@@ -9,28 +9,37 @@ const getAllEvents = async (req, res) => {
         { path: 'owner', select: 'name' },
         { path: 'participants.user', select: 'name' }
       ])
-      .sort({ eventDate: -1 }); // Most recent first
+      .sort({ eventDate: -1 });
 
-    // Calculate total and remaining balance for each event
-    const eventsWithTotals = await Promise.all(
-      events.map(async (event) => {
-        const items = await ExpenseItem.find({ eventId: event._id });
-        const totalAmount = items.reduce((sum, item) => sum + item.amount, 0);
-        
-        // Calculate remaining balance (total amount - amount paid by participants)
-        const participantCount = event.participants.length;
-        const perPersonAmount = participantCount > 0 ? totalAmount / participantCount : 0;
-        const totalAmountPaid = event.participants.reduce((sum, p) => sum + (p.amountPaid || 0), 0);
-        const remainingBalance = Math.max(0, totalAmount - totalAmountPaid);
-        
-        return {
-          ...event.toObject(),
-          totalAmount,
-          itemCount: items.length,
-          remainingBalance
-        };
-      })
-    );
+    if (events.length === 0) {
+      return res.json([]);
+    }
+
+    const eventIds = events.map(e => e._id);
+    const allItems = await ExpenseItem.find({ eventId: { $in: eventIds } });
+
+    const itemsByEvent = {};
+    for (const item of allItems) {
+      const eid = item.eventId.toString();
+      if (!itemsByEvent[eid]) itemsByEvent[eid] = [];
+      itemsByEvent[eid].push(item);
+    }
+
+    const eventsWithTotals = events.map(event => {
+      const items = itemsByEvent[event._id.toString()] || [];
+      const totalAmount = items.reduce((sum, item) => sum + item.amount, 0);
+
+      const participantCount = event.participants.length;
+      const totalAmountPaid = event.participants.reduce((sum, p) => sum + (p.amountPaid || 0), 0);
+      const remainingBalance = Math.max(0, totalAmount - totalAmountPaid);
+
+      return {
+        ...event.toObject(),
+        totalAmount,
+        itemCount: items.length,
+        remainingBalance
+      };
+    });
 
     res.json(eventsWithTotals);
   } catch (error) {
@@ -242,6 +251,41 @@ const updateParticipantPaymentAmount = async (req, res) => {
   }
 };
 
+// POST /api/events/:id/items/batch
+const addEventItemBatch = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { items } = req.body;
+
+    if (!items || !Array.isArray(items) || items.length === 0) {
+      return res.status(400).json({ error: 'items array is required' });
+    }
+
+    for (const item of items) {
+      if (!item.itemName || !item.amount || item.amount <= 0) {
+        return res.status(400).json({ error: 'Each item needs itemName and a positive amount' });
+      }
+    }
+
+    const event = await Event.findById(id);
+    if (!event) {
+      return res.status(404).json({ error: 'Event not found' });
+    }
+
+    const expenseItems = items.map(item => ({
+      eventId: id,
+      itemName: item.itemName,
+      amount: item.amount
+    }));
+
+    const created = await ExpenseItem.insertMany(expenseItems);
+
+    res.status(201).json(created);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+};
+
 module.exports = {
   getAllEvents,
   getEventById,
@@ -250,5 +294,6 @@ module.exports = {
   deleteEvent,
   getEventItems,
   addEventItem,
+  addEventItemBatch,
   updateParticipantPaymentAmount
 };

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -2,11 +2,13 @@
 const { User, Event, ExpenseItem } = require('../models');
 
 // GET /api/users [?search=<term>]
+const escapeRegex = (str) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 const getAllUsers = async (req, res) => {
   try {
     const { search } = req.query;
     const filter = search
-      ? { name: { $regex: search, $options: 'i' } }
+      ? { name: { $regex: escapeRegex(search), $options: 'i' } }
       : {};
 
     const users = await User.find(filter, '-passwordHash');

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -1,55 +1,78 @@
 // server/controllers/userController.js
 const { User, Event, ExpenseItem } = require('../models');
 
-// GET /api/users
+// GET /api/users [?search=<term>]
 const getAllUsers = async (req, res) => {
   try {
-    const users = await User.find({}, '-passwordHash'); // Exclude password hash
-    
-    // Calculate running balance for each user
-    const usersWithBalance = await Promise.all(
-      users.map(async (user) => {
-        // Find all events where user is a participant BUT NOT the owner
-        const events = await Event.find({
-          'participants.user': user._id,
-          owner: { $ne: user._id }  // Exclude events owned by this user
-        }).populate('participants.user', 'name');
+    const { search } = req.query;
+    const filter = search
+      ? { name: { $regex: search, $options: 'i' } }
+      : {};
 
-        let totalOwed = 0;
-        let totalOwedToUser = 0;
+    const users = await User.find(filter, '-passwordHash');
 
-        for (const event of events) {
-          // Get expense items for this event
-          const expenseItems = await ExpenseItem.find({ eventId: event._id });
-          const eventTotal = expenseItems.reduce((sum, item) => sum + item.amount, 0);
-          
-          // Find user's participation info
-          const userParticipation = event.participants.find(p => p.user._id.toString() === user._id.toString());
-          const participantCount = event.participants.length;
-          const userShare = participantCount > 0 ? eventTotal / participantCount : 0;
-          const amountPaid = userParticipation ? userParticipation.amountPaid || 0 : 0;
-          const amountOwed = Math.max(0, userShare - amountPaid);
-          
-          totalOwed += amountOwed;
-        }
+    if (users.length === 0) {
+      return res.json([]);
+    }
 
-        // Calculate amount owed to user from events they own
-        const ownedEvents = await Event.find({ owner: user._id });
-        for (const event of ownedEvents) {
-          const expenseItems = await ExpenseItem.find({ eventId: event._id });
-          const eventTotal = expenseItems.reduce((sum, item) => sum + item.amount, 0);
-          const totalAmountPaid = event.participants.reduce((sum, p) => sum + (p.amountPaid || 0), 0);
-          const remainingBalance = Math.max(0, eventTotal - totalAmountPaid);
-          totalOwedToUser += remainingBalance;
-        }
+    const userIds = users.map(u => u._id);
 
-        return {
-          ...user.toObject(),
-          runningBalance: totalOwed,
-          amountOwedToUser: totalOwedToUser
-        };
-      })
-    );
+    const [participatedEvents, ownedEvents] = await Promise.all([
+      Event.find({ 'participants.user': { $in: userIds } }),
+      Event.find({ owner: { $in: userIds } })
+    ]);
+
+    const relevantEventIds = [
+      ...new Set([
+        ...participatedEvents.map(e => e._id.toString()),
+        ...ownedEvents.map(e => e._id.toString())
+      ])
+    ];
+
+    const allExpenseItems = await ExpenseItem.find({ eventId: { $in: relevantEventIds } });
+
+    const expenseItemsByEvent = {};
+    for (const item of allExpenseItems) {
+      const eid = item.eventId.toString();
+      if (!expenseItemsByEvent[eid]) expenseItemsByEvent[eid] = [];
+      expenseItemsByEvent[eid].push(item);
+    }
+
+    const getUserEventTotal = (eventId) => {
+      const items = expenseItemsByEvent[eventId.toString()] || [];
+      return items.reduce((sum, item) => sum + item.amount, 0);
+    };
+
+    const usersWithBalance = users.map(user => {
+      const uid = user._id.toString();
+      let totalOwed = 0;
+      let totalOwedToUser = 0;
+
+      for (const event of participatedEvents) {
+        const isParticipant = event.participants.some(p => p.user.toString() === uid);
+        if (!isParticipant || event.owner.toString() === uid) continue;
+
+        const eventTotal = getUserEventTotal(event._id);
+        const userParticipation = event.participants.find(p => p.user.toString() === uid);
+        const participantCount = event.participants.length;
+        const userShare = participantCount > 0 ? eventTotal / participantCount : 0;
+        const amountPaid = userParticipation ? userParticipation.amountPaid || 0 : 0;
+        totalOwed += Math.max(0, userShare - amountPaid);
+      }
+
+      for (const event of ownedEvents) {
+        if (event.owner.toString() !== uid) continue;
+        const eventTotal = getUserEventTotal(event._id);
+        const totalAmountPaid = event.participants.reduce((sum, p) => sum + (p.amountPaid || 0), 0);
+        totalOwedToUser += Math.max(0, eventTotal - totalAmountPaid);
+      }
+
+      return {
+        ...user.toObject(),
+        runningBalance: totalOwed,
+        amountOwedToUser: totalOwedToUser
+      };
+    });
 
     res.json(usersWithBalance);
   } catch (error) {

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -8,6 +8,7 @@ const {
   deleteEvent,
   getEventItems,
   addEventItem,
+  addEventItemBatch,
   updateParticipantPaymentAmount
 } = require('../controllers/eventController');
 
@@ -24,6 +25,7 @@ router.delete('/:id', deleteEvent);
 // Expense item routes (nested under events)
 router.get('/:id/items', getEventItems);
 router.post('/:id/items', addEventItem);
+router.post('/:id/items/batch', addEventItemBatch);
 
 // Payment amount routes
 router.patch('/:id/participants/:participantId/payment', updateParticipantPaymentAmount);


### PR DESCRIPTION
## Phase 2: Performance Fixes

### 2.1 — Eliminate duplicate data fetching
- Removed `useDataFetching()` call from `Header.js` (it was running independently alongside App.js)
- Pass `users`, `events`, `eventsLoaded`, `allDataLoaded`, `refreshData` as props from `App.js`

### 2.2 — Fix N+1 queries
- **getAllUsers**: Replaced per-user nested queries (O(N x Ex EI)) with batched approach: 1 users query + 2 events queries + 1 expense items query = 4 total
- **getAllEvents**: Replaced per-event `ExpenseItem.find()` loop with single batched `$in` query (N -> 1 query)

### 2.3 — Server-side user search
- Added `GET /api/users?search=<term>` with `$regex` query in `getAllUsers`
- Updated `CreateEventForm.js` `searchUsers` and `searchOwners` to use server-side search
- Updated `EventDetailView.js` `searchUsers` to use server-side search

### 2.4 — Batch expense items endpoint
- Added `POST /api/events/:id/items/batch` using `insertMany`
- Updated `CreateEventForm.js` `handleSubmit` to use batch endpoint instead of `for...of` sequential POSTs
- Removed redundant client-side expense item deletion in `deleteEvent` (server already cascades)

---

## Follow-up fix (post-review)

### 2.5 — Escape regex metacharacters in user search
The `$regex` query in `getAllUsers` passed the user-supplied `search` term straight into the regex pattern, allowing ReDoS / regex injection (e.g. `search=.*.*.*.*`).

- Added `escapeRegex()` helper that escapes `.*+?^${}()|[]\` before the term is passed to `$regex`
- The 100-char length cap (from `validateUserSearch` middleware) limits blast radius but escaping is the correct fix

**Files:** `server/controllers/userController.js`
